### PR TITLE
fix: add missing @radix-ui/react-slot dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@napi-rs/canvas": "^0.1.88",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-switch": "^1.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react@19.2.14)(react@19.2.3)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
## Summary
- `ui/buttons/Button.tsx` imports `Slot` from `@radix-ui/react-slot` but the package was not listed as a direct dependency in `package.json`
- This caused TypeScript build failures on Vercel: `Cannot find module '@radix-ui/react-slot'`
- The package was already in `pnpm-lock.yaml` as a transitive dep (v1.2.3) — just needed to be declared explicitly

## Test Plan
- [ ] Vercel build passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)